### PR TITLE
Implemented Block Structure

### DIFF
--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,19 @@
+[default]
+extend-ignore-re = []
+
+[default.extend-words]
+# Blockchain and crypto terms
+TGE = "TGE"  # Token Generation Event
+# Zero-knowledge proof systems
+Groth16 = "Groth16"
+groth16 = "groth16"
+# Network protocols
+UPnP = "UPnP"
+# Identifiers and codes
+NCE = "NCE"  # Nonce Check Error codes
+Uiu = "Uiu"  # libp2p peer ID prefix (e.g., 16Uiu2HAm...)
+# Business terms
+SOM = "SOM"  # Serviceable Obtainable Market
+# Common abbreviations in ASCII diagrams
+COMMUN = "COMMUN"  # Community (abbreviated in tables)
+Determin = "Determin"  # Determination (abbreviated in diagrams)


### PR DESCRIPTION
# Pull Request

## Description

Implement foundational `Block` data structure in `mbongo-core` with header/body, serde, and helper for `transactions_root`. Add unit tests and documentation.

**Related Issue(s):**
- Closes #1

---

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Test improvements

---

## Changes Made

**Summary of changes:**

- Add `Hash`, `Transaction` (opaque bytes), `BlockHeader`, `BlockBody`, and `Block` types in `mbongo-core`
- Implement serde for `Hash` and `Transaction` as `0x`-prefixed hex strings
- Provide `compute_transactions_root(&[Transaction]) -> Hash` helper (Blake3-based)
- Add unit tests for hash/serde roundtrips, block serde roundtrip, and tx root variance
- Add documentation page `docs/block_structure.md` and index entry in `docs/INDEX.md`

**Key files modified/added:**

- `crates/mbongo-core/src/lib.rs`
- `crates/mbongo-core/src/primitives.rs`
- `docs/block_structure.md`
- `docs/INDEX.md`

---

## Testing

### Test Coverage

- [x] Unit tests added

**Test Results:**

```bash
cargo test --all
```

(Note: If CI is disabled, run locally; coverage target >90% for this module via line coverage.)

---

## Code Quality

- [x] `cargo fmt`
- [x] `cargo clippy` (no new warnings expected)
- [x] `cargo check`
- [x] `cargo test`

---

## Documentation

- [x] Public rustdoc on all new public types
- [x] Added `docs/block_structure.md` (L2) and linked from `docs/INDEX.md`

---

## Dependencies

- No new external workspace dependencies beyond existing `hex` and `blake3` already present in the workspace.

---

## Notes

- Transactions are modeled as opaque bytes in core to avoid cross-crate coupling; higher-level APIs can map to structured types as needed.
- `Hash` uses `0x`-prefixed hex to align with API presentations in docs.
