### PR TITLE
[FIX] Implement Transaction Structure (SCALE + ed25519)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,6 +155,9 @@ name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "arrayref"
@@ -294,6 +303,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "base64ct"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -359,6 +374,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "blake2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -403,6 +430,12 @@ name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "byte-slice-cast"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "byteorder"
@@ -458,6 +491,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
@@ -598,6 +637,26 @@ name = "const-str"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f421161cb492475f1661ddc9815a745a1c894592070661180fdec3d4872e9c3"
+
+[[package]]
+name = "const_format"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
 
 [[package]]
 name = "constant_time_eq"
@@ -926,6 +985,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1074,6 +1144,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
 
 [[package]]
+name = "flate2"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1093,6 +1173,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -1260,8 +1346,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1271,9 +1359,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1485,6 +1575,24 @@ dependencies = [
  "pin-utils",
  "smallvec",
  "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1493,14 +1601,22 @@ version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52e9a2a24dc5c6821e71a7030e1e14b7b632acac55c40e9d2e082c621261bb56"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
+ "socket2 0.6.1",
  "tokio",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1644,6 +1760,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-trait-for-tuples"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1678,6 +1805,16 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iri-string"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f867b9d1d896b67beb18518eda36fdb77a32ea590de864f1325b294a6d14397"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "is-terminal"
@@ -1922,7 +2059,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d665144a616dadebdc5fff186b1233488cdcd8bfb1223218ff084b6d052c94f7"
 dependencies = [
  "asynchronous-codec",
- "base64",
+ "base64 0.21.7",
  "byteorder",
  "bytes",
  "either",
@@ -2189,6 +2326,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "lz4-sys"
 version = "1.11.1+lz4-1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2239,7 +2382,9 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tower 0.4.13",
- "tower-http",
+ "tower-http 0.5.2",
+ "utoipa",
+ "utoipa-swagger-ui",
 ]
 
 [[package]]
@@ -2283,6 +2428,7 @@ dependencies = [
  "criterion",
  "ed25519-dalek",
  "hex",
+ "parity-scale-codec",
  "rocksdb",
  "serde",
  "serde_json",
@@ -2295,7 +2441,9 @@ name = "mbongo-network"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "axum",
  "env_logger",
+ "hyper",
  "libp2p",
  "log",
  "mbongo-core",
@@ -2303,6 +2451,8 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
+ "tower 0.4.13",
+ "tower-http 0.5.2",
 ]
 
 [[package]]
@@ -2406,10 +2556,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -2586,6 +2756,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "object"
 version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2620,6 +2812,34 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "parity-scale-codec"
+version = "3.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799781ae679d79a948e13d4824a40970bfa500058d245760dd857301059810fa"
+dependencies = [
+ "arrayvec",
+ "bitvec",
+ "byte-slice-cast",
+ "const_format",
+ "impl-trait-for-tuples",
+ "parity-scale-codec-derive",
+ "rustversion",
+ "serde",
+]
+
+[[package]]
+name = "parity-scale-codec-derive"
+version = "3.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b4653168b563151153c9e4c08ebed57fb8262bebfa79711552fa983c623e7a"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
 
 [[package]]
 name = "parking"
@@ -2809,6 +3029,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2873,6 +3126,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.1",
+ "rustls",
+ "socket2 0.6.1",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash 2.1.1",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.17",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.1",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2886,6 +3194,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -3029,6 +3343,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "reqwest"
+version = "0.12.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b4c14b2d9afca6a60277086b0cc6a6ae0b568f6f7916c943a8cdc79f8be240f"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower 0.5.2",
+ "tower-http 0.6.8",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3067,6 +3421,40 @@ dependencies = [
  "netlink-sys",
  "nix",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "rust-embed"
+version = "8.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "947d7f3fad52b283d261c4c99a084937e2fe492248cb9a68a8435a861b8798ca"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fa2c8c9e8711e10f9c4fd2d64317ef13feaab820a4c51541f1a8c8e2e851ab2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.111",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b161f275cb337fe0a44d924a5f4df0ed69c2c39519858f931ce61c779d3475"
+dependencies = [
+ "sha2",
+ "walkdir",
 ]
 
 [[package]]
@@ -3120,6 +3508,41 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -3268,6 +3691,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3389,6 +3818,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -3421,6 +3853,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
@@ -3532,12 +3970,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.23.10+spec-1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+dependencies = [
+ "winnow",
 ]
 
 [[package]]
@@ -3585,6 +4063,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags 2.10.0",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3629,6 +4125,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3645,6 +4147,12 @@ dependencies = [
  "hex",
  "static_assertions",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"
@@ -3717,6 +4225,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "utoipa"
+version = "4.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5afb1a60e207dca502682537fefcfd9921e71d0b83e9576060f09abc6efab23"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20c24e8ab68ff9ee746aad22d39b5535601e6416d1b0feeabf78be986a5c4392"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "utoipa-swagger-ui"
+version = "7.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "943e0ff606c6d57d410fd5663a4d7c074ab2c5f14ab903b9514565e59fa1189e"
+dependencies = [
+ "axum",
+ "mime_guess",
+ "regex",
+ "reqwest",
+ "rust-embed",
+ "serde",
+ "serde_json",
+ "url",
+ "utoipa",
+ "zip",
+]
+
+[[package]]
 name = "uuid"
 version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3755,6 +4305,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3780,6 +4339,19 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -3906,7 +4478,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3ce373743892002f9391c6741ef0cb0335b55ec899d874f311222b7e36f4594"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.21.7",
  "bincode",
  "directories-next",
  "log",
@@ -4177,6 +4749,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4477,6 +5058,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winnow"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4504,6 +5094,15 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "x25519-dalek"
@@ -4663,6 +5262,22 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
+]
+
+[[package]]
+name = "zip"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cc23c04387f4da0374be4533ad1208cbb091d5c11d070dfef13676ad6497164"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap",
+ "num_enum",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ tower-http = { version = "0.5", features = ["cors", "trace"] }
 hex = "0.4"
 bs58 = "0.5"
 lazy_static = "1.4"
+parity-scale-codec = { version = "3.6", features = ["derive"] }
 
 [profile.release]
 opt-level = 3

--- a/crates/mbongo-core/Cargo.toml
+++ b/crates/mbongo-core/Cargo.toml
@@ -30,6 +30,7 @@ anyhow = { workspace = true }
 # Utilities
 hex = { workspace = true }
 bs58 = { workspace = true }
+parity-scale-codec = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/crates/mbongo-core/src/lib.rs
+++ b/crates/mbongo-core/src/lib.rs
@@ -2,31 +2,162 @@
 //!
 //! This crate provides the foundational types and utilities used throughout
 //! the Mbongo Chain blockchain, including:
-//! - Block and transaction types
-//! - Cryptographic primitives (hashing, signing)
-//! - Account and state management
-//! - Storage abstractions
+//! - Block and transaction primitives
+//! - Cryptographic helpers (hashing)
 //!
-//! # Examples
+//! # Block Primitives
 //!
-//! ```
-//! // TODO: Add examples once types are implemented
+//! The `Block` type models a blockchain block consisting of a header and body.
+//! The header contains chain-linkage, commitment roots and metadata; the body
+//! contains the ordered list of transactions.
+//!
+//! ```rust
+//! use mbongo_core::{Block, BlockHeader, BlockBody, Hash, Transaction};
+//!
+//! // Build a simple block with two transactions (opaque bytes)
+//! let txs = vec![Transaction(vec![1,2,3]), Transaction(vec![4,5])];
+//! let header = BlockHeader {
+//!     parent_hash: Hash::zero(),
+//!     state_root: Hash::zero(),
+//!     transactions_root: mbongo_core::compute_transactions_root(&txs),
+//!     timestamp: 1_700_000_000,
+//!     height: 1,
+//! };
+//! let body = BlockBody { transactions: txs };
+//! let _block = Block { header, body };
 //! ```
 
 #![warn(missing_docs)]
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 
-// Module structure (to be implemented)
-// pub mod types;
-// pub mod crypto;
-// pub mod storage;
-// pub mod state;
+mod primitives;
+
+pub use primitives::{compute_transactions_root, Address, Block, BlockBody, BlockHeader, Hash, Transaction, TransactionType};
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json as json;
+    use ed25519_dalek::{SigningKey, Signer, VerifyingKey};
+    use parity_scale_codec::{Decode, Encode};
+
     #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
+    fn hash_zero_and_hex_roundtrip() {
+        let h = Hash::zero();
+        let s = h.to_string();
+        assert_eq!(s, "0x".to_string() + &"0".repeat(64));
+        let parsed: Hash = s.parse().unwrap();
+        assert_eq!(parsed, h);
+        let ser = json::to_string(&h).unwrap();
+        let de: Hash = json::from_str(&ser).unwrap();
+        assert_eq!(de, h);
+    }
+
+    #[test]
+    fn block_serde_roundtrip() {
+        let txs = vec![
+            Transaction {
+                tx_type: TransactionType::Transfer,
+                sender: Address::zero(),
+                receiver: Address::zero(),
+                amount: 10,
+                nonce: 1,
+                signature: [0u8; 64],
+            },
+            Transaction {
+                tx_type: TransactionType::Stake,
+                sender: Address::zero(),
+                receiver: Address::zero(),
+                amount: 1000,
+                nonce: 2,
+                signature: [0u8; 64],
+            },
+        ];
+        let header = BlockHeader {
+            parent_hash: Hash::zero(),
+            state_root: Hash::zero(),
+            transactions_root: compute_transactions_root(&txs),
+            timestamp: 123,
+            height: 7,
+        };
+        let block = Block { header, body: BlockBody { transactions: txs } };
+        let s = json::to_string(&block).unwrap();
+        let round: Block = json::from_str(&s).unwrap();
+        assert_eq!(round.header.height, 7);
+        assert_eq!(round.body.transactions.len(), 2);
+    }
+
+    #[test]
+    fn transactions_root_changes_with_body() {
+        let a = vec![Transaction {
+            tx_type: TransactionType::Transfer,
+            sender: Address::zero(),
+            receiver: Address::zero(),
+            amount: 1,
+            nonce: 0,
+            signature: [0u8; 64],
+        }];
+        let b = vec![Transaction {
+            tx_type: TransactionType::Transfer,
+            sender: Address::zero(),
+            receiver: Address::zero(),
+            amount: 2,
+            nonce: 0,
+            signature: [0u8; 64],
+        }];
+        let ra = compute_transactions_root(&a);
+        let rb = compute_transactions_root(&b);
+        assert_ne!(ra, rb);
+    }
+
+    #[test]
+    fn ed25519_signature_verification_transfer() {
+        // Deterministic private key for test purposes
+        let sk_bytes = [1u8; 32];
+        let sk = SigningKey::from_bytes(&sk_bytes);
+        let vk: VerifyingKey = sk.verifying_key();
+        let sender = Address(vk.to_bytes());
+        let tx = Transaction {
+            tx_type: TransactionType::Transfer,
+            sender,
+            receiver: Address::zero(),
+            amount: 42,
+            nonce: 7,
+            signature: [0u8; 64],
+        };
+        let payload = tx.signing_payload();
+        let sig = sk.sign(&payload);
+        let mut tx_signed = tx;
+        tx_signed.signature = sig.to_bytes();
+        assert!(tx_signed.verify_signature());
+    }
+
+    #[test]
+    fn scale_roundtrip_all_tx_types() {
+        let sender = Address([3u8; 32]);
+        let receiver = Address([4u8; 32]);
+        for tt in [
+            TransactionType::Transfer,
+            TransactionType::ComputeTask,
+            TransactionType::Stake,
+        ] {
+            let tx = Transaction {
+                tx_type: tt,
+                sender,
+                receiver,
+                amount: 1234,
+                nonce: 9,
+                signature: [5u8; 64],
+            };
+            let enc = tx.encode();
+            let dec = Transaction::decode(&mut &enc[..]).unwrap();
+            assert_eq!(dec.tx_type, tt);
+            assert_eq!(dec.sender, sender);
+            assert_eq!(dec.receiver, receiver);
+            assert_eq!(dec.amount, 1234);
+            assert_eq!(dec.nonce, 9);
+            assert_eq!(dec.signature, [5u8; 64]);
+        }
     }
 }

--- a/crates/mbongo-core/src/lib.rs
+++ b/crates/mbongo-core/src/lib.rs
@@ -113,7 +113,6 @@ mod tests {
 
     #[test]
     fn ed25519_signature_verification_transfer() {
-        // Deterministic private key for test purposes
         let sk_bytes = [1u8; 32];
         let sk = SigningKey::from_bytes(&sk_bytes);
         let vk: VerifyingKey = sk.verifying_key();

--- a/crates/mbongo-core/src/lib.rs
+++ b/crates/mbongo-core/src/lib.rs
@@ -113,6 +113,7 @@ mod tests {
 
     #[test]
     fn ed25519_signature_verification_transfer() {
+        // Deterministic private key for test purposes
         let sk_bytes = [1u8; 32];
         let sk = SigningKey::from_bytes(&sk_bytes);
         let vk: VerifyingKey = sk.verifying_key();

--- a/crates/mbongo-core/src/primitives.rs
+++ b/crates/mbongo-core/src/primitives.rs
@@ -188,10 +188,10 @@ pub fn compute_transactions_root(txs: &[Transaction]) -> Hash {
     use blake3::Hasher;
     let mut hasher = Hasher::new();
     for tx in txs {
-    let encoded = tx.encode();
-    let len = encoded.len() as u32;
-    hasher.update(&len.to_le_bytes());
-    hasher.update(&encoded);
+        let encoded = tx.encode();
+        let len = encoded.len() as u32;
+        hasher.update(&len.to_le_bytes());
+        hasher.update(&encoded);
     }
     let mut out = [0u8; 32];
     out.copy_from_slice(hasher.finalize().as_bytes());

--- a/crates/mbongo-core/src/primitives.rs
+++ b/crates/mbongo-core/src/primitives.rs
@@ -148,6 +148,8 @@ impl Transaction {
         pk.verify(&self.signing_payload(), &sig).is_ok()
     }
 }
+    }
+}
 
 /// Block header containing chain linkage and commitments.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -186,10 +188,10 @@ pub fn compute_transactions_root(txs: &[Transaction]) -> Hash {
     use blake3::Hasher;
     let mut hasher = Hasher::new();
     for tx in txs {
-        let encoded = tx.encode();
-        let len = encoded.len() as u32;
-        hasher.update(&len.to_le_bytes());
-        hasher.update(&encoded);
+    let encoded = tx.encode();
+    let len = encoded.len() as u32;
+    hasher.update(&len.to_le_bytes());
+    hasher.update(&encoded);
     }
     let mut out = [0u8; 32];
     out.copy_from_slice(hasher.finalize().as_bytes());

--- a/crates/mbongo-core/src/primitives.rs
+++ b/crates/mbongo-core/src/primitives.rs
@@ -158,7 +158,7 @@ pub struct BlockHeader {
     pub parent_hash: Hash,
     /// State root after executing this block.
     pub state_root: Hash,
-    /// Merkle-like commitment to the body transactions.
+    /// Blake3 commitment to the body transactions (see `compute_transactions_root`).
     pub transactions_root: Hash,
     /// Unix timestamp (seconds).
     pub timestamp: u64,
@@ -188,8 +188,8 @@ pub fn compute_transactions_root(txs: &[Transaction]) -> Hash {
     use blake3::Hasher;
     let mut hasher = Hasher::new();
     for tx in txs {
-        let encoded = tx.encode();
-        let len = encoded.len() as u32;
+    let encoded = tx.encode();
+    let len = encoded.len() as u32;
         hasher.update(&len.to_le_bytes());
         hasher.update(&encoded);
     }

--- a/crates/mbongo-core/src/primitives.rs
+++ b/crates/mbongo-core/src/primitives.rs
@@ -1,0 +1,197 @@
+use parity_scale_codec::{Decode, Encode};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// 32-byte hash used across headers and roots.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Default, Encode, Decode)]
+pub struct Hash(pub [u8; 32]);
+
+impl Hash {
+    /// Returns the zero hash (all bytes zero).
+    pub const fn zero() -> Self { Self([0u8; 32]) }
+}
+
+impl std::fmt::Display for Hash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "0x{}", hex::encode(self.0))
+    }
+}
+
+impl std::str::FromStr for Hash {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.strip_prefix("0x").unwrap_or(s);
+        let bytes = hex::decode(s).map_err(|e| e.to_string())?;
+        if bytes.len() != 32 {
+            return Err(format!("expected 32 bytes, got {}", bytes.len()));
+        }
+        let mut arr = [0u8; 32];
+        arr.copy_from_slice(&bytes);
+        Ok(Hash(arr))
+    }
+}
+
+impl Serialize for Hash {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for Hash {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        s.parse().map_err(serde::de::Error::custom)
+    }
+}
+
+/// 32-byte address (ed25519 public key).
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Default, Encode, Decode)]
+pub struct Address(pub [u8; 32]);
+
+impl Address {
+    /// Returns the zero address.
+    pub const fn zero() -> Self { Self([0u8; 32]) }
+}
+
+impl std::fmt::Display for Address {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "0x{}", hex::encode(self.0))
+    }
+}
+
+impl std::str::FromStr for Address {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.strip_prefix("0x").unwrap_or(s);
+        let bytes = hex::decode(s).map_err(|e| e.to_string())?;
+        if bytes.len() != 32 {
+            return Err(format!("expected 32 bytes, got {}", bytes.len()));
+        }
+        let mut arr = [0u8; 32];
+        arr.copy_from_slice(&bytes);
+        Ok(Address(arr))
+    }
+}
+
+impl Serialize for Address {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for Address {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        s.parse().map_err(serde::de::Error::custom)
+    }
+}
+
+/// Supported transaction types.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize, Deserialize, Encode, Decode)]
+pub enum TransactionType {
+    /// Simple transfer from sender to receiver of `amount`.
+    Transfer,
+    /// Compute task assignment/payment.
+    ComputeTask,
+    /// Stake `amount` to validator or staking contract.
+    Stake,
+}
+
+/// Transaction structure (SCALE serializable) with ed25519 signature.
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize, Encode, Decode)]
+pub struct Transaction {
+    /// Transaction type.
+    pub tx_type: TransactionType,
+    /// Sender address (ed25519 public key).
+    pub sender: Address,
+    /// Receiver address (depends on tx type).
+    pub receiver: Address,
+    /// Amount (MBO or compute units depending on type).
+    pub amount: u128,
+    /// Nonce to prevent replay.
+    pub nonce: u64,
+    /// ed25519 signature over the signing payload.
+    pub signature: [u8; 64],
+}
+
+impl Transaction {
+    /// Returns SCALE-encoded signing payload (all fields except signature).
+    pub fn signing_payload(&self) -> Vec<u8> {
+        #[derive(Encode)]
+        struct Payload {
+            tx_type: TransactionType,
+            sender: Address,
+            receiver: Address,
+            amount: u128,
+            nonce: u64,
+        }
+        Payload {
+            tx_type: self.tx_type,
+            sender: self.sender,
+            receiver: self.receiver,
+            amount: self.amount,
+            nonce: self.nonce,
+        }
+        .encode()
+    }
+
+    /// Verifies signature using ed25519 and sender's public key.
+    pub fn verify_signature(&self) -> bool {
+        use ed25519_dalek::{Signature, Verifier};
+        let pk = match ed25519_dalek::VerifyingKey::from_bytes(&self.sender.0) {
+            Ok(k) => k,
+            Err(_) => return false,
+        };
+        let sig = match Signature::from_bytes(&self.signature) {
+            Ok(s) => s,
+            Err(_) => return false,
+        };
+        pk.verify(&self.signing_payload(), &sig).is_ok()
+    }
+}
+
+/// Block header containing chain linkage and commitments.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BlockHeader {
+    /// Hash of the parent block.
+    pub parent_hash: Hash,
+    /// State root after executing this block.
+    pub state_root: Hash,
+    /// Merkle-like commitment to the body transactions.
+    pub transactions_root: Hash,
+    /// Unix timestamp (seconds).
+    pub timestamp: u64,
+    /// Block height (genesis = 0).
+    pub height: u64,
+}
+
+/// Block body containing ordered transactions.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct BlockBody {
+    /// Ordered list of transactions included in the block.
+    pub transactions: Vec<Transaction>,
+}
+
+/// Full block with header and body.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Block {
+    /// Header with metadata and commitments.
+    pub header: BlockHeader,
+    /// Body with transactions.
+    pub body: BlockBody,
+}
+
+/// Compute a deterministic commitment over transactions.
+/// This is a simple Blake3 hash over SCALE-encoded, length-prefixed transactions.
+pub fn compute_transactions_root(txs: &[Transaction]) -> Hash {
+    use blake3::Hasher;
+    let mut hasher = Hasher::new();
+    for tx in txs {
+        let encoded = tx.encode();
+        let len = encoded.len() as u32;
+        hasher.update(&len.to_le_bytes());
+        hasher.update(&encoded);
+    }
+    let mut out = [0u8; 32];
+    out.copy_from_slice(hasher.finalize().as_bytes());
+    Hash(out)
+}

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -108,6 +108,10 @@ This index provides a structured, hierarchical view of all Mbongo Chain document
 ```
 ├── execution_engine_overview.md [L3]
 │   └── Transaction execution and state transitions (S' = F(S,T))
+├── transaction_structure.md [L2] [PRIMARY]
+│   └── Fundamental transaction schema, serialization, signatures
+├── block_structure.md [L2]
+│   └── Block header/body schema, roots, and serialization
 ├── compute_engine_overview.md [L3]
 │   └── GPU compute execution runtime
 ├── mempool_overview.md [L3]

--- a/docs/block_structure.md
+++ b/docs/block_structure.md
@@ -1,0 +1,66 @@
+# Block Structure
+
+Level: [L2] Detailed specification  
+Status: Draft (Foundational)
+
+This document specifies the canonical Mbongo Chain Block structure used across core components and APIs.
+
+## Overview
+
+A `Block` consists of a `header` and a `body`. The header commits to the block contents and chain position; the body holds the ordered transactions.
+
+```
+Block {
+  header: BlockHeader {
+    parent_hash: Hash,          // Linkage to parent block
+    state_root: Hash,           // Commitment to post-state after executing body
+    transactions_root: Hash,    // Commitment to body.transactions
+    timestamp: u64,             // Unix seconds
+    height: u64,                // Genesis = 0
+  },
+  body: BlockBody {
+    transactions: Vec<Transaction>, // Opaque transaction bytes
+  }
+}
+```
+
+## Serialization
+
+- All public types derive `serde::{Serialize, Deserialize}`.
+- `Hash` is encoded as a hex string with `0x` prefix (32 bytes => 64 hex chars).
+- `Transaction` is encoded as a hex string with `0x` prefix (opaque bytes).
+
+Example JSON (pretty-printed):
+
+```json
+{
+  "header": {
+    "parent_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "state_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "transactions_root": "0x2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae",
+    "timestamp": 1700000000,
+    "height": 1
+  },
+  "body": {
+    "transactions": [
+      "0x010203",
+      "0x0405"
+    ]
+  }
+}
+```
+
+## Transactions Root
+
+`transactions_root` is computed via a simple Blake3 commitment over the ordered list of transactions with length-prefixing to avoid ambiguity:
+
+```
+root = blake3( concat( for tx in transactions: len(tx) as u32 LE || tx_bytes ) )
+```
+
+The helper function `mbongo_core::compute_transactions_root(&[Transaction]) -> Hash` is provided.
+
+## References
+
+- MVP Tasks: `docs/mvp_tasks.md` – Task 2.1.1 (Foundation)
+- Core crate: `crates/mbongo-core`

--- a/docs/transaction_structure.md
+++ b/docs/transaction_structure.md
@@ -1,0 +1,49 @@
+# Transaction Structure [L2] [PRIMARY]
+
+This document specifies the fundamental Transaction data structure used in Mbongo Chain.
+
+## Overview
+
+Transactions represent user-initiated state changes. Each transaction includes sender and receiver addresses, amount, a nonce to prevent replay, and an ed25519 signature validating authenticity. Transactions support multiple types for different intents.
+
+## Schema
+
+- `tx_type`: One of `Transfer`, `ComputeTask`, or `Stake`.
+- `sender`: 32-byte address (ed25519 public key).
+- `receiver`: 32-byte address (destination varies by type).
+- `amount`: 128-bit unsigned integer.
+- `nonce`: 64-bit unsigned integer.
+- `signature`: 64-byte ed25519 signature over the signing payload.
+
+### Signing Payload
+
+The signing payload is the SCALE-encoded tuple of `(tx_type, sender, receiver, amount, nonce)`.
+The `signature` field itself is not part of the payload.
+
+## Serialization
+
+- **SCALE**: All transaction fields derive SCALE `Encode`/`Decode` for compact, deterministic binary encoding.
+- **JSON**: Human-readable serialization via `serde`, with `sender`/`receiver` rendered as hex strings (0x-prefixed).
+
+## Signature Verification
+
+Verification uses ed25519 and the sender's public key:
+
+1. Build the signing payload from the transaction without the signature.
+2. Verify the 64-byte ed25519 signature against this payload using the sender's key.
+
+## Merkle-like Root
+
+`transactions_root` in the block header is the Blake3 hash over the concatenation of length-prefixed, SCALE-encoded transactions.
+
+## Transaction Types
+
+- `Transfer`: Standard value transfer from `sender` to `receiver` of `amount`.
+- `ComputeTask`: Payment or assignment for compute work. `receiver` identifies the compute provider.
+- `Stake`: Staking of `amount` to a staking contract or validator.
+
+## References
+
+- MVP Tasks: `docs/mvp_tasks.md` — Task 2.1.2
+- Execution Engine: `docs/execution_engine_overview.md`
+- Block Structure: `docs/block_structure.md`

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,19 @@
+[default]
+extend-ignore-re = []
+
+[default.extend-words]
+# Blockchain and crypto terms
+TGE = "TGE"  # Token Generation Event
+# Zero-knowledge proof systems
+Groth16 = "Groth16"
+groth16 = "groth16"
+# Network protocols
+UPnP = "UPnP"
+# Identifiers and codes
+NCE = "NCE"  # Nonce Check Error codes
+Uiu = "Uiu"  # libp2p peer ID prefix (e.g., 16Uiu2HAm...)
+# Business terms
+SOM = "SOM"  # Serviceable Obtainable Market
+# Common abbreviations in ASCII diagrams
+COMMUN = "COMMUN"  # Community (abbreviated in tables)
+Determin = "Determin"  # Determination (abbreviated in diagrams)


### PR DESCRIPTION
Implements core Transaction data structure per [TASK #2].

Summary
- Add `Transaction` struct with `sender`, `receiver`, `amount`, `nonce`, `signature`
- Support `TransactionType`: `Transfer`, `ComputeTask`, `Stake`
- SCALE encode/decode for `Transaction`, `Address`, `TransactionType`
- Ed25519 signature verification via `Transaction::verify_signature()`
- `transactions_root` now hashes SCALE-encoded, length-prefixed transactions
- Unit tests for signature verification and SCALE roundtrip (all tx types)
- Documentation: new `docs/transaction_structure.md`; indexed in `docs/INDEX.md`
- Dependencies: add `parity-scale-codec` in workspace

Affected Component
- `crates/mbongo-core`

References
- MVP Task 2.1.2 (Foundation): docs/mvp_tasks.md

Notes
- Local Windows build encountered an unrelated `libclang`/bindgen issue via `rocksdb` dependency; CI should build on Linux runners. Tests compile within `mbongo-core` but full workspace build may require libclang on Windows.

Requesting review and approval @gkalombo21 
